### PR TITLE
Simplify the use of UtilityTimer

### DIFF
--- a/wconsteroids/wconsteroids/CommandLineParser.cpp
+++ b/wconsteroids/wconsteroids/CommandLineParser.cpp
@@ -49,10 +49,6 @@ CommandLineParser::CommandLineParser(int argc, char* argv[],
 bool CommandLineParser::parse(ExecutionCtrlValues& execVars)
 {
 	UtilityTimer stopWatch;
-	// There is no way to determine if -t has been used at this point
-	// so start the timer anyway.
-	stopWatch.startTimer();
-
 	bool hasFiles = false;
 
 	extractAllArguments();

--- a/wconsteroids/wconsteroids/main.cpp
+++ b/wconsteroids/wconsteroids/main.cpp
@@ -38,10 +38,6 @@ int main(int argc, char* argv[])
 		if (cmdLineParser.parse(executionCtrl))
 		{
 			UtilityTimer stopWatch;
-			if (executionCtrl.options.enableExecutionTime)
-			{
-				stopWatch.startTimer();
-			}
 			mainLoop(executionCtrl);
 			if (executionCtrl.options.enableExecutionTime)
 			{


### PR DESCRIPTION
Because the constructor already sets "start" there is no point to calling startTimer() immediately after contruction.