### PR TITLE
Reduce FileProcessor to a single public function

### DIFF
--- a/wconsteroids/wconsteroids/FileProcessor.cpp
+++ b/wconsteroids/wconsteroids/FileProcessor.cpp
@@ -8,43 +8,7 @@
 
 static constexpr std::size_t InputBufferSize = 8 * 1024;
 
-FileProcessor::FileProcessor(std::vector<std::string> filesToProcess,
-                             const ProgramOptions& progOptions)
-    : fileNames { std::move(filesToProcess) },
-      options{ progOptions }
-{
-}
-
-std::string FileProcessor::processAllFiles() noexcept
-{
-	ReportWriter TotalsReporter(options);
-	FileStatistics allFiles;
-
-	std::string resultsToDisplay(TotalsReporter.getColumnHeadingAsOneString());
-
-	for (auto currentFile : fileNames)
-	{
-		try
-		{
-			std::string fileResults = processFile(currentFile, allFiles);
-			if (!fileResults.empty())
-			{
-				resultsToDisplay += fileResults;
-			}
-		}
-		catch (const std::runtime_error& re)
-		{
-			std::cerr << re.what() << "\n";
-		}
-	}
-
-	resultsToDisplay += TotalsReporter.getColumnHeadingAsOneString();
-	resultsToDisplay += TotalsReporter.getResultText(allFiles);
-
-	return resultsToDisplay;
-}
-
-void FileProcessor::processLoop(std::ifstream& inStream,
+static void processLoop(std::ifstream& inStream,
 	FileStatistics& statistics) noexcept
 {
 	StatisticsCollector fileAnalyzer(statistics);
@@ -58,7 +22,7 @@ void FileProcessor::processLoop(std::ifstream& inStream,
  * Processing a file includes reading the file, analyzing the input to collect
  * the statistics and then pringing the statistics.
  */
-std::string FileProcessor::processFile(std::string fileName,
+static std::string processFile(const ProgramOptions& options, std::string fileName,
 	FileStatistics& totalStats)
 {
 	std::string fileResults;
@@ -101,4 +65,34 @@ std::string FileProcessor::processFile(std::string fileName,
 	}
 
 	return fileResults;
+}
+
+std::string processAllFiles(const std::vector<std::string>& fileNames,
+                             const ProgramOptions& progOptions)
+{
+	ReportWriter TotalsReporter(progOptions);
+	FileStatistics allFiles;
+
+	std::string resultsToDisplay(TotalsReporter.getColumnHeadingAsOneString());
+
+	for (const auto& currentFile : fileNames)
+	{
+		try
+		{
+			std::string fileResults = processFile(progOptions, currentFile, allFiles);
+			if (!fileResults.empty())
+			{
+				resultsToDisplay += fileResults;
+			}
+		}
+		catch (const std::runtime_error& re)
+		{
+			std::cerr << re.what() << "\n";
+		}
+	}
+
+	resultsToDisplay += TotalsReporter.getColumnHeadingAsOneString();
+	resultsToDisplay += TotalsReporter.getResultText(allFiles);
+
+	return resultsToDisplay;
 }

--- a/wconsteroids/wconsteroids/FileProcessor.h
+++ b/wconsteroids/wconsteroids/FileProcessor.h
@@ -5,24 +5,10 @@
 #include <vector>
 #include <fstream>
 
-class FileStatistics;
 class ProgramOptions;
 
-class FileProcessor
-{
-public:
-	FileProcessor(std::vector<std::string> filesToProcess, const ProgramOptions& progOptions);
-	~FileProcessor() = default;
-	std::string processAllFiles() noexcept;
+std::string processAllFiles(const std::vector<std::string>& fileNames,
+                             const ProgramOptions& progOptions);
 
-protected:
-	void processLoop(std::ifstream& inStream, FileStatistics& statistics) noexcept;
-	std::string processFile(std::string fileName, FileStatistics& totalStats);
-
-private:
-	std::vector<std::string> fileNames;
-	// The program options are necessary to know what to outout.
-	const ProgramOptions& options;
-};
 
 #endif // FILE_PROCESSOR_H

--- a/wconsteroids/wconsteroids/main.cpp
+++ b/wconsteroids/wconsteroids/main.cpp
@@ -8,20 +8,6 @@
 #include "ProgramOptions.h"
 #include "UtilityTimer.h"
 
-static void mainLoop(ExecutionCtrlValues& executionCtrl)
-{
-	std::string resultsToDisplay;
-
-	ProgramOptions& options = executionCtrl.options;
-	std::vector<std::string> filesToProcess = executionCtrl.filesToProcess;
-
-	FileProcessor fileProcessor(filesToProcess, options);
-	resultsToDisplay = fileProcessor.processAllFiles();
-	// Yes we want to flush the standard output. All possible output has been
-	// collected.
-	std::cout << resultsToDisplay << std::endl;
-}
-
 int main(int argc, char* argv[])
 {
 	ExecutionCtrlValues executionCtrl;
@@ -38,7 +24,7 @@ int main(int argc, char* argv[])
 		if (cmdLineParser.parse(executionCtrl))
 		{
 			UtilityTimer stopWatch;
-			mainLoop(executionCtrl);
+                        std::cout << processAllFiles(executionCtrl.filesToProcess, executionCtrl.options) << std::endl;
 			if (executionCtrl.options.enableExecutionTime)
 			{
 				stopWatch.stopTimerAndReport(


### PR DESCRIPTION
This greatly simplifies the interface for FileProcessor which is no longer a class but a single function, and also benefits from not having to copy what could be a relatively large std::vector<std::string>.