### PR TITLE
Simplify CommandLineParser constructor

### DIFF
--- a/wconsteroids/wconsteroids/CommandLineParser.cpp
+++ b/wconsteroids/wconsteroids/CommandLineParser.cpp
@@ -23,24 +23,7 @@ CommandLineParser::CommandLineParser(int argc, char* argv[],
 	: program_name{ simplify_name(argv[0]) },
 	args(argv + 1, argv + argc),
 	version{ std::move(progVersion) },
-	programName{ argv[0] },
-	options{ ProgramOptions() },
-	doubleDashArgs{
-		{ "--bytes", options.byteCount },
-		{ "--chars", options.charCount },
-		{ "--lines", options.lineCount },
-		{ "--max-line-length", options.maxLineWidth },
-		{ "--words", options.wordCount }
-	},
-	singleDashArgs{
-		{ 'c', options.byteCount },
-		{ 'm', options.charCount },
-		{ 'l', options.lineCount },
-		{ 'L', options.maxLineWidth },
-		{ 'w', options.wordCount }
-	},
-	NotFlagsArgs{ {} },
-	useDefaultFlags{ true }
+	programName{ argv[0] }
 {
 
 }
@@ -48,7 +31,6 @@ CommandLineParser::CommandLineParser(int argc, char* argv[],
 bool CommandLineParser::parse(ExecutionCtrlValues& execVars)
 {
 	UtilityTimer stopWatch;
-	bool hasFiles = false;
 
 	extractAllArguments();
 	if (useDefaultFlags)
@@ -64,7 +46,7 @@ bool CommandLineParser::parse(ExecutionCtrlValues& execVars)
 		stopWatch.stopTimerAndReport("command line parsing at ");
 	}
 
-	return hasFiles = execVars.filesToProcess.size() != 0;
+	return execVars.filesToProcess.size() != 0;
 }
 
 void CommandLineParser::printHelpMessage() const

--- a/wconsteroids/wconsteroids/CommandLineParser.h
+++ b/wconsteroids/wconsteroids/CommandLineParser.h
@@ -38,11 +38,23 @@ private:
 	std::vector<std::string_view> args;
 	std::string_view version;
 	std::string_view programName;
-	ProgramOptions options;
-	std::unordered_map<std::string_view, bool&> doubleDashArgs;
-	std::unordered_map<char, bool&> singleDashArgs;
-	std::vector<std::string_view> NotFlagsArgs;
-	bool useDefaultFlags;
+	ProgramOptions options{};
+	const std::unordered_map<std::string_view, bool&> doubleDashArgs{
+		{ "--bytes", options.byteCount },
+		{ "--chars", options.charCount },
+		{ "--lines", options.lineCount },
+		{ "--max-line-length", options.maxLineWidth },
+		{ "--words", options.wordCount }
+	};
+	const std::unordered_map<char, bool&> singleDashArgs{
+		{ 'c', options.byteCount },
+		{ 'm', options.charCount },
+		{ 'l', options.lineCount },
+		{ 'L', options.maxLineWidth },
+		{ 'w', options.wordCount }
+	};
+	std::vector<std::string_view> NotFlagsArgs{};
+	bool useDefaultFlags = true;
 };
 
 #endif // COMMAND_LINE_PARSER_H


### PR DESCRIPTION
This makes the option maps const and puts more of initialization as in-class initializers rather than in a constructor.